### PR TITLE
Return `self` when slicing array with its own indices

### DIFF
--- a/NewtonianKitTests/Time/Array+Initializer.swift
+++ b/NewtonianKitTests/Time/Array+Initializer.swift
@@ -16,7 +16,7 @@ extension Array {
       count <= 0
       ? .init()
       : .init(
-        unsafeUninitializedCapacity: Swift.max(count, 1),
+        unsafeUninitializedCapacity: count,
         initializingWith: { buffer, initializedCount in
           for index in 0..<count {
             buffer.baseAddress?.advanced(by: index).initialize(to: initializer(index))

--- a/NewtonianKitTests/Time/Array+Slice.swift
+++ b/NewtonianKitTests/Time/Array+Slice.swift
@@ -13,15 +13,11 @@ extension Array {
   /// - Returns: Another ``Array`` with `indices.count` elements of this one, or this one itself in
   ///   case the specified ``indices`` equal to those of this ``Array``.
   func sliced(_ bounds: Range<Index>) -> [Element] {
-    if bounds.isEmpty {
-      return []
-    } else if bounds.count == 1 {
-      return [self[bounds.lowerBound]]
-    } else if bounds == self.indices {
-      return self
-    } else {
-      let sequencedBounds = bounds.map { bound in bound }
-      return .init(count: sequencedBounds.count) { index in self[sequencedBounds[index]] }
-    }
+    guard bounds != self.indices else { return self }
+    guard !bounds.isEmpty else { return [] }
+    guard bounds.count > 1 else { return [self[bounds.lowerBound]] }
+    var bounds = bounds.map { bound in bound }
+    while bounds.endIndex > endIndex { let _ = bounds.popLast() }
+    return .init(count: bounds.count) { index in self[bounds[index]] }
   }
 }

--- a/NewtonianKitTests/Time/Array+SliceTests.swift
+++ b/NewtonianKitTests/Time/Array+SliceTests.swift
@@ -5,6 +5,7 @@
 //  Created by Jean Barros Silva on 03/05/25.
 //
 
+import Foundation
 import Testing
 
 struct ArraySliceTests {
@@ -12,9 +13,18 @@ struct ArraySliceTests {
     #expect([0, 1, 2, 3].sliced(0..<0).isEmpty)
   }
 
-  @Test func returnsOriginalArrayWhenSlicingWithIndicesEqualToItsOwn() throws {
-    let elements = [0, 1, 2, 3]
-    #expect(elements.sliced(0..<4) == elements)
+  @Test func returnsOriginalSingleElementArrayWhenSlicingWithIndicesEqualToItsOwn() throws {
+    let elements = [NSObject()]
+    let slice = elements.sliced(0..<1)
+    #expect(slice.count == 1)
+    #expect(slice[0] === elements[0])
+  }
+
+  @Test func returnsOriginalMultiElementArrayWhenSlicingWithIndicesEqualToItsOwn() throws {
+    let elements = [NSObject](count: 4) { _ in NSObject() }
+    let slice = elements.sliced(0..<5)
+    #expect(slice.count == 4)
+    for (index, element) in slice.enumerated() { #expect(element === elements[index]) }
   }
 
   @Test func slices() throws {


### PR DESCRIPTION
When slicing an array, a new one would be instantiated even if the original one was empty or had a single element.