### PR TITLE
Unimport NewtownianKit from array tests

### DIFF
--- a/NewtonianKitTests/Time/Array+TransformTests.swift
+++ b/NewtonianKitTests/Time/Array+TransformTests.swift
@@ -5,16 +5,15 @@
 //  Created by Jean Barros Silva on 02/05/25.
 //
 
+import Foundation
 import Testing
-
-@testable import NewtonianKit
 
 struct ArrayTransformTests {
   @Test func transformsBasedOnEachElement() async throws {
-    let unmappedElements = [CountingOnTickListener](count: 2) { _ in CountingOnTickListener() }
+    let unmappedElements = [NSObject](count: 2) { _ in NSObject() }
     let mappedElements = await unmappedElements.map { listener in listener }
-    for (index, onTickListener) in mappedElements.enumerated() {
-      #expect(onTickListener === unmappedElements[index])
+    for (index, mappedElement) in mappedElements.enumerated() {
+      #expect(mappedElement === unmappedElements[index])
     }
   }
 


### PR DESCRIPTION
Referencing [`CountingOnTickListener`](https://github.com/jeanbarrossilva/Deus/blob/3a097f25be864ae9ea5a05a525c1fd572036f317/NewtonianKitTests/Time/CountingOnTickListener.swift) is unnecessary due to the generic nature of the extension.