### PR TITLE
Ensure clock stops in test by resuming subticker and advancing it

### DIFF
--- a/NewtonianKitTests/Time/ClockTests.swift
+++ b/NewtonianKitTests/Time/ClockTests.swift
@@ -49,9 +49,11 @@ struct ClockTests {
   }
 
   @Test mutating func stopsSubtickerUponStop() async throws {
+    await subticker.advance(by: .ticks(2))
     await clock.stop()
     await subticker.advance(by: .ticks(2))
-    #expect(await subticker.elapsedTime == .zero)
+    await subticker.resume()
+    #expect(await subticker.elapsedTime == .ticks(2))
   }
 
   @Test mutating func removesOnTickListenersUponStop() async throws {


### PR DESCRIPTION
https://github.com/jeanbarrossilva/Deus/blob/780a89246984d666327b2425f2a4a9a118f44ef4/NewtonianKitTests/Time/ClockTests.swift#L51-L57

The portion above is what has been modified.

The test was being done by calling [`Clock.stop()`](https://github.com/jeanbarrossilva/Deus/blob/780a89246984d666327b2425f2a4a9a118f44ef4/NewtonianKit/Time/Clock.swift#L168), advancing the subticker and expecting its elapsed time to be zero; this, however, does not fully guarantee that the clock was effectively stopped, as it would behave the same if it were stopped.

To ensure the stop, time is now advanced by two ticks, the clock is stopped, time is advanced by two ticks again and the subticker is resumed. In case the clock was merely paused instead of paused, such resumption would trigger both time advancements, and the elapsed time would be of four ticks. When really stopped, it of only two, given that the first advancement is "forgotten" and the second one is scheduled to be made upon resumption.