### PR TITLE
Remove unecessary error for unknown clock on-tick listener

### DIFF
--- a/NewtonianKit/Time/Clock.swift
+++ b/NewtonianKit/Time/Clock.swift
@@ -48,25 +48,6 @@ protocol OnTickListener: AnyObject {
   func onTick() async
 }
 
-/// ``Error`` thrown when no ``OnTickListener`` satisfies the critieria for removal from a
-///  ``Clock``, either because none with the given ID was found or was, but its type does not match
-///  the specified one.
-///
-/// - SeeAlso: ``Clock.add(onTickListener:)``
-/// - SeeAlso: ``Clock.removeOnTickListener(identifiedAs:)``
-struct UnknownTickListenerError: Error {
-  /// Type of the unknown ``OnTickListener``.
-  let type: OnTickListener.Type?
-
-  /// ID of the unknown ``OnTickListener``.
-  let id: UUID
-
-  fileprivate init(type: OnTickListener.Type?, id: UUID) {
-    self.type = type
-    self.id = id
-  }
-}
-
 /// Coordinates the passage of time in a simulated universe, allowing for the movement of bodies and
 /// other time-based changes to their properties (such as temperature, size, direction, velocity,
 /// route, etc.).


### PR DESCRIPTION
Such error was being (kind of) useful when I was experimenting with noncopyable types, as adding an on-tick listener to a clock would consume that listener and it would be retrievable by being removed; since it was a requirement that a listener with the given ID existed when removing it, that error was thrown in case it was nonexistent.

I, then, learned that there are both [value and reference types](https://www.swift.org/documentation/articles/value-and-reference-types.html) in Swift, and that hassle suddenly seemed unnecessary.