### PR TITLE
Contextualize clock time lapse listeners

### DIFF
--- a/NewtonianKit/Time/Duration.swift
+++ b/NewtonianKit/Time/Duration.swift
@@ -7,17 +7,20 @@
 
 /// Amount of time in a given unit.
 enum Duration: AdditiveArithmetic, Strideable {
+  static let zero = Self.microseconds(0)
+
+  /// Amount of microseconds — the backing unit of a ``Duration`` — in milliseconds.
+  static let millisecondFactor = 1_000
+
   /// Backing, raw value of this ``Duration`` in microseconds.
-  private var inMicroseconds: Int {
+  var inMicroseconds: Int {
     switch self {
     case .microseconds(let value):
       value
     case .milliseconds(let value):
-      value * 1_000
+      value * Self.millisecondFactor
     }
   }
-
-  static let zero = Self.microseconds(0)
 
   /// Whether this amount of time is zero or contains a whole millisecond.
   ///
@@ -26,7 +29,7 @@ enum Duration: AdditiveArithmetic, Strideable {
   var containsWholeMillisecond: Bool {
     switch self {
     case .microseconds(let value):
-      value % 1_000 == 0
+      value % Self.millisecondFactor == 0
     case .milliseconds(_):
       true
     }

--- a/NewtonianKitTests/Time/CountingTimeLapseListener.swift
+++ b/NewtonianKitTests/Time/CountingTimeLapseListener.swift
@@ -16,7 +16,12 @@ final class CountingTimeLapseListener: TimeLapseListener {
   /// Amount of times ticks have been notified to this ``CountingTimeLapseListener``.
   private(set) var count = 0
 
-  func timeDidElapse() async {
+  func timeDidElapse(
+    from start: Duration,
+    after previous: Duration?,
+    to current: Duration,
+    toward end: Duration
+  ) async {
     count += 1
   }
 }

--- a/NewtonianKitTests/Time/CountingTimeLapseListenerTests.swift
+++ b/NewtonianKitTests/Time/CountingTimeLapseListenerTests.swift
@@ -15,8 +15,19 @@ struct CountingTimeLapseListenerTests {
   }
 
   @Test func counts() async throws {
-    let timeLapseListener = CountingTimeLapseListener()
-    for _ in 0..<64 { await timeLapseListener.timeDidElapse() }
-    #expect(timeLapseListener.count == 64)
+    let listener = CountingTimeLapseListener()
+    let lapse =
+      stride(from: Duration.zero, to: .milliseconds(64), by: Duration.millisecondFactor).map {
+        meantime in meantime
+      }
+    for meantime in lapse {
+      await listener.timeDidElapse(
+        from: lapse.first!,
+        after: meantime == .zero ? nil : meantime - .milliseconds(1),
+        to: meantime,
+        toward: lapse.last!
+      )
+    }
+    #expect(listener.count == 64)
   }
 }

--- a/NewtonianKitTests/Time/DurationTests.swift
+++ b/NewtonianKitTests/Time/DurationTests.swift
@@ -26,6 +26,10 @@ struct DurationTests {
     #expect(Duration.microseconds(2_000).containsWholeMillisecond)
   }
 
+  @Test func millisecondFactorEqualsToAmountOfMicrosecondsInOneMillisecond() throws {
+    #expect(Duration.millisecondFactor == Duration.milliseconds(1).inMicroseconds)
+  }
+
   @Test(arguments: 0...128)
   func wholeMillisecondIsContained(by value: Int) throws {
     #expect(Duration.milliseconds(value).containsWholeMillisecond)


### PR DESCRIPTION
Partially addresses #11 by providing information about the time at which a clock advancement has started, the previous time, the current and the end (target) one.