### PR TITLE
Move within-duration tick comprisability check to clock

### DIFF
--- a/NewtonianKit/Time/Clock.swift
+++ b/NewtonianKit/Time/Clock.swift
@@ -168,7 +168,7 @@ actor Clock {
     let end = start + advancement
     for meantime in start...end {
       elapsedTime = meantime
-      guard elapsedTime.containsWholeMillisecond && (meantime == start || lastSubtickTime != start)
+      guard elapsedTime.comprisesWholeTicksOnly && (meantime == start || lastSubtickTime != start)
       else { continue }
       for listener in timeLapseListeners {
         await listener.timeDidElapse(
@@ -181,7 +181,7 @@ actor Clock {
     }
     lastSubtickTime = elapsedTime
   }
-
+  
   /// Pauses the passage of time.
   ///
   /// Calling ``start()`` after having called this function resumes the passage of time from where
@@ -212,4 +212,9 @@ actor Clock {
     timeLapseListeners.insert(listener)
     return listener.id
   }
+}
+
+extension Duration {
+  /// Whether an integer amount of ticks can be performed by a ``Clock`` within this ``Duration``.
+  fileprivate var comprisesWholeTicksOnly: Bool { inMicroseconds % Self.millisecondFactor == 0 }
 }

--- a/NewtonianKit/Time/Duration.swift
+++ b/NewtonianKit/Time/Duration.swift
@@ -9,29 +9,19 @@
 enum Duration: AdditiveArithmetic, Strideable {
   static let zero = Self.microseconds(0)
 
-  /// Amount of microseconds — the backing unit of a ``Duration`` — in milliseconds.
+  /// Amount of microseconds — the backing unit of a ``Duration`` — in a microsecond. Logically, 1.
+  static let microsecondFactor = 1
+
+  /// Amount of microseconds — the backing unit of a ``Duration`` — in a millisecond.
   static let millisecondFactor = 1_000
 
   /// Backing, raw value of this ``Duration`` in microseconds.
   var inMicroseconds: Int {
     switch self {
     case .microseconds(let value):
-      value
+      value * Self.microsecondFactor
     case .milliseconds(let value):
       value * Self.millisecondFactor
-    }
-  }
-
-  /// Whether this amount of time is zero or contains a whole millisecond.
-  ///
-  /// - SeeAlso: ``zero``
-  /// - SeeAlso: ``.microseconds(_:)``
-  var containsWholeMillisecond: Bool {
-    switch self {
-    case .microseconds(let value):
-      value % Self.millisecondFactor == 0
-    case .milliseconds(_):
-      true
     }
   }
 


### PR DESCRIPTION
Moves the declaration of [`Duration.containsWholeMilliscond`](https://github.com/jeanbarrossilva/Deus/blob/5b6a04272cfaa9bdf9c111297336a03b6f98e8fc/NewtonianKit/Time/Duration.swift#L29) to [`Clock.swift`](https://github.com/jeanbarrossilva/Deus/blob/5b6a04272cfaa9bdf9c111297336a03b6f98e8fc/NewtonianKit/Time/Clock.swift) and renames it to "comprisesWholeTicksOnly".