### PR TITLE
Update `Duration` tests

### DIFF
--- a/Deus.xcodeproj/xcuserdata/jeanbarrossilva.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Deus.xcodeproj/xcuserdata/jeanbarrossilva.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>NewtonianKit.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>

--- a/NewtonianKitTests/Time/DurationTests.swift
+++ b/NewtonianKitTests/Time/DurationTests.swift
@@ -18,20 +18,7 @@ struct DurationTests {
     #expect(Duration.zero == .milliseconds(0))
   }
 
-  @Test func nonThousandDivisibleAmountOfMicrosecondsDoesNotContainWholeMillisecond() throws {
-    #expect(!Duration.microseconds(2_048).containsWholeMillisecond)
-  }
-
-  @Test func thousandDivisibleAmountOfMicrosecondsContainsWholeMillisecond() throws {
-    #expect(Duration.microseconds(2_000).containsWholeMillisecond)
-  }
-
   @Test func millisecondFactorEqualsToAmountOfMicrosecondsInOneMillisecond() throws {
     #expect(Duration.millisecondFactor == Duration.milliseconds(1).inMicroseconds)
-  }
-
-  @Test(arguments: 0...128)
-  func wholeMillisecondIsContained(by value: Int) throws {
-    #expect(Duration.milliseconds(value).containsWholeMillisecond)
   }
 }


### PR DESCRIPTION
Tests were still referencing `Duration.containsWholeMillisecond` (changed by #16).