### PR TITLE
Replace `Clock.stop()` by `Clock.reset()`

### DIFF
--- a/NewtonianKit/Time/Clock.swift
+++ b/NewtonianKit/Time/Clock.swift
@@ -190,11 +190,11 @@ actor Clock {
     isInterrupted = true
   }
 
-  /// Stops the passage of time, resetting this ``Clock``.
+  /// Resets this ``Clock``, stopping the passage of time.
   ///
   /// Calling ``start()`` after having called this function starts the passage of time from the
   /// beginning.
-  func stop() async {
+  func reset() async {
     timeLapseListeners.removeAll()
     guard !isInterrupted else { return }
     isInterrupted = true

--- a/NewtonianKitTests/Time/ClockTests.swift
+++ b/NewtonianKitTests/Time/ClockTests.swift
@@ -19,7 +19,7 @@ struct ClockTests {
   @Test func elapsedTimeIncreasesPerSubtick() async throws {
     await clock.advanceTime(by: .microseconds(2))
     #expect(await clock.elapsedTime == .microseconds(2))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test func ignoresTimeAdvancementsWhenStartedAfterPaused() async throws {
@@ -27,15 +27,15 @@ struct ClockTests {
     await clock.advanceTime(by: .microseconds(2))
     await clock.start()
     #expect(await clock.elapsedTime == .zero)
-    await clock.stop()
+    await clock.reset()
   }
 
-  @Test func ignoresTimeAdvancementsWhenStartedAfterStopped() async throws {
-    await clock.stop()
+  @Test func ignoresTimeAdvancementsWhenStartedAfterReset() async throws {
+    await clock.reset()
     await clock.advanceTime(by: .microseconds(2))
     await clock.start()
     #expect(await clock.elapsedTime == .zero)
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test(arguments: [
@@ -46,7 +46,7 @@ struct ClockTests {
     for listener in timeLapseListeners { let _ = await clock.addTimeLapseListener(listener) }
     await clock.advanceTime(by: .milliseconds(2))
     for listener in timeLapseListeners { #expect(listener.count == 3) }
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test
@@ -56,7 +56,7 @@ struct ClockTests {
     let _ =
       await clock.addTimeLapseListener { start, _, _, _ in #expect(start == .milliseconds(2)) }
     await clock.advanceTime(by: .milliseconds(2))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test
@@ -68,7 +68,7 @@ struct ClockTests {
     }
     let _ = await clock.addTimeLapseListener(listener)
     await clock.advanceTime(by: .milliseconds(1))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test func previousTimePassedIntoTimeLapseListenerEqualsToLastElapsedOneAtPause() async throws {
@@ -85,9 +85,9 @@ struct ClockTests {
     }
     let _ = await clock.addTimeLapseListener(listener)
     await clock.advanceTime(by: .milliseconds(2))
-    await clock.pause()
+    await clock.reset()
     await clock.advanceTime(by: .milliseconds(1))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test
@@ -99,7 +99,7 @@ struct ClockTests {
     }
     let _ = await clock.addTimeLapseListener(listener)
     await clock.advanceTime(by: .milliseconds(2))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test func currentTimePassedIntoTimeLapseListenerEqualsToElapsedOneOfClock() async throws {
@@ -107,7 +107,7 @@ struct ClockTests {
       #expect(await current == clock.elapsedTime)
     }
     await clock.advanceTime(by: .milliseconds(2))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test
@@ -115,7 +115,7 @@ struct ClockTests {
   {
     let _ = await clock.addTimeLapseListener { _, _, _, end in #expect(end == .milliseconds(2)) }
     await clock.advanceTime(by: .milliseconds(2))
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test(arguments: [
@@ -128,7 +128,7 @@ struct ClockTests {
     for id in ids { await clock.removeTimeLapseListener(identifiedAs: id) }
     await clock.advanceTime(by: .milliseconds(2))
     for listener in timeLapseListeners { #expect(listener.count == 0) }
-    await clock.stop()
+    await clock.reset()
   }
 
   @Test mutating func pauses() async throws {
@@ -139,9 +139,9 @@ struct ClockTests {
     #expect(await clock.elapsedTime == .milliseconds(4))
   }
 
-  @Test mutating func stops() async throws {
+  @Test mutating func resets() async throws {
     await clock.advanceTime(by: .milliseconds(2))
-    await clock.stop()
+    await clock.reset()
     await clock.advanceTime(by: .milliseconds(2))
     await clock.start()
     #expect(await clock.elapsedTime == .zero)
@@ -151,9 +151,9 @@ struct ClockTests {
     [CountingTimeLapseListener()],
     [CountingTimeLapseListener](count: 2) { _ in CountingTimeLapseListener() },
   ])
-  mutating func removesUponStop(timeLapseListeners: [CountingTimeLapseListener]) async throws {
+  mutating func removesUponReset(timeLapseListeners: [CountingTimeLapseListener]) async throws {
     for listener in timeLapseListeners { let _ = await clock.addTimeLapseListener(listener) }
-    await clock.stop()
+    await clock.reset()
     await clock.advanceTime(by: .milliseconds(2))
     for listener in timeLapseListeners { #expect(listener.count == 0) }
   }


### PR DESCRIPTION
The name "stop" did not clearly indicate that the previous state of the clock would be cleared upon a call to the function. "Reset" denotes that both the elapsed time will be zeroed and the added time lapse listeners will be removed.