### PR TITLE
Specify specific colors

### DIFF
--- a/StandardModel/Chromodynamics/Color.swift
+++ b/StandardModel/Chromodynamics/Color.swift
@@ -36,25 +36,25 @@ public let blue = Blue()
 /// Final state of confined ``ColoredParticleLike``s whose net ``Color`` charge is zero, making them
 /// effectively colorless. Results from the combination of ``Color``-anticolor pairs or of all
 /// ``SingleColor``s (``red`` + ``green`` + ``blue``).
-public class White: Color { fileprivate init() {} }
+public class White: Color, SpecificColor { fileprivate init() {} }
 
 /// Red (r) direction in the ``Color`` field.
-public class Red: SingleColor { fileprivate init() {} }
+public class Red: SingleColor, SpecificColor { fileprivate init() {} }
 
 /// Green (g) direction in the ``Color`` field.
-public class Green: SingleColor { fileprivate init() {} }
+public class Green: SingleColor, SpecificColor { fileprivate init() {} }
 
 /// Blue (b) direction in the ``Color`` field.
-public class Blue: SingleColor { fileprivate init() {} }
+public class Blue: SingleColor, SpecificColor { fileprivate init() {} }
 
 /// Antired (r̄) direction in the ``Color`` field.
-private class Antired: SingleColor { fileprivate init() {} }
+private class Antired: SingleColor, SpecificColor { fileprivate init() {} }
 
 /// Antigreen (ḡ) direction in the ``Color`` field.
-private class Antigreen: SingleColor { fileprivate init() {} }
+private class Antigreen: SingleColor, SpecificColor { fileprivate init() {} }
 
 /// Antiblue (b̄) direction in the ``Color`` field.
-private class Antiblue: SingleColor { fileprivate init() {} }
+private class Antiblue: SingleColor, SpecificColor { fileprivate init() {} }
 
 // MARK: Color and single-color-like declarations
 
@@ -81,6 +81,8 @@ public protocol SingleColorLike: Color {}
 
 extension Anti: Color, SingleColorLike where Counterpart: SingleColor {}
 
+extension Anti: SpecificColor where Counterpart: SingleColor & SpecificColor {}
+
 /// Type-erased ``SingleColorLike``. Might be ``red``, antired, ``green``, antigreen, ``blue`` or
 /// antiblue.
 public struct AnySingleColorLike: Discrete, SingleColor {
@@ -98,6 +100,10 @@ public struct AnySingleColorLike: Discrete, SingleColor {
 
   public func `is`(_ other: (some Color).Type) -> Bool { type(of: base) == other }
 }
+
+/// ``Color`` whose type has not been erased (i.e., non-``AnySingleColor`` or
+/// -``AnySingleColorLike``).
+public protocol SpecificColor: Color {}
 
 /// Color charge is a fundamental, confined (unobservable while free) property which determines its
 /// transformation under the SU(3) gauge symmetry whose field, SU(3)₍color₎ or gluon field, is

--- a/StandardModel/Composite/Pion/NegativePion.swift
+++ b/StandardModel/Composite/Pion/NegativePion.swift
@@ -35,7 +35,7 @@ public struct NegativePion: Equatable, Pion {
   }
 }
 
-extension DownQuark {
+extension DownQuark where Color: SpecificColor {
   /// Combines an up antiquark to this ``DownQuark``.
   ///
   /// - Parameters:

--- a/StandardModel/Composite/Pion/PositivePion.swift
+++ b/StandardModel/Composite/Pion/PositivePion.swift
@@ -35,7 +35,7 @@ public struct PositivePion: Equatable, Pion {
   }
 }
 
-extension UpQuark {
+extension UpQuark where Color: SpecificColor {
   /// Combines a down antiquark to this ``UpQuark``.
   ///
   /// - Parameters:


### PR DESCRIPTION
Distinguishes specific colors from type-erased ones.

This is specifically important for hadron formation. In the case of pions, for example, a positively charged one is the result of combining an up quark and a down antiquark (u + d̄ → π⁺). After #27, quark-likes and colors are able to have their type erased, which introduces potential inconsistency, given that an up quark whose color is erased can have a down antiquark whose anticolor is also erased combined to it, while, in reality, the anticolor should be the exact opposite of that of the color of the up quark — not just any anticolor.

E.g., prior to this change, the expression below would compile successfully:

```swift
UpQuark(color: AnySingleColor(red)) + Anti(DownQuark(color: AnySingleColor(green)))
```

Such combination is impossible according to the Standard Model, because [the net color charge of the formed particle would not be white/zero](https://fafnir.phyast.pitt.edu/particles/color.html).

This PR introduces a new protocol to which all non-erased color implementations conform: [`SpecificColor`](https://github.com/jeanbarrossilva/Deus/blob/ed9e8cbb861f300adf15266b6f52d2c3beae2b8e/StandardModel/Chromodynamics/Color.swift#L106). Conformance to such protocol is, now, required in order to form charged pions.