### PR TITLE
Correct testing of removal of time lapse listener of a clock

### DIFF
--- a/RelativityKitTests/ClockTests.swift
+++ b/RelativityKitTests/ClockTests.swift
@@ -220,6 +220,7 @@ struct ClockTests {
   func removesUponReset(timeLapseListeners: [CountingTimeLapseListener]) async throws {
     for listener in timeLapseListeners { let _ = await clock.addTimeLapseListener(listener) }
     await clock.reset()
+    await clock.start()
     await clock.advanceTime(by: .milliseconds(2), spacing: .linear)
     for listener in timeLapseListeners { #expect(listener.count == 0) }
   }


### PR DESCRIPTION
Closes #32.