### PR TITLE
Implement fields

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,4 +1,5 @@
 {
+  "indentConditionalCompilationBlocks": false,
   "lineBreakBeforeEachArgument": true,
   "lineBreakBetweenDeclarationAttributes": true,
   "multiElementCollectionTrailingCommas": false,

--- a/Deus.xcodeproj/project.pbxproj
+++ b/Deus.xcodeproj/project.pbxproj
@@ -143,8 +143,17 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				DiscretionTests.swift.gyb,
+				Elementary/QuarkTests.swift.gyb,
+				MeasurementTests.swift.gyb,
 			);
 			target = 49EF5D562DE20D36008AFB31 /* QuantumMechanicsTests */;
+		};
+		498F54242EDB2CFF00FB4D53 /* Exceptions for "QuantumMechanics" folder in "QuantumMechanics" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Measurement+Differentiable.swift.gyb",
+			);
+			target = 49EF5D4E2DE20D36008AFB31 /* QuantumMechanics */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -196,6 +205,9 @@
 		};
 		49EF5D502DE20D36008AFB31 /* QuantumMechanics */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				498F54242EDB2CFF00FB4D53 /* Exceptions for "QuantumMechanics" folder in "QuantumMechanics" target */,
+			);
 			path = QuantumMechanics;
 			sourceTree = "<group>";
 		};

--- a/QuantumMechanics/Field/Manifold.swift
+++ b/QuantumMechanics/Field/Manifold.swift
@@ -1,0 +1,30 @@
+// ===-------------------------------------------------------------------------------------------===
+// Copyright © 2025 Supernova. All rights reserved.
+//
+// This file is part of the Deus open-source project.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program. If
+// not, see https://www.gnu.org/licenses.
+// ===-------------------------------------------------------------------------------------------===
+
+#if canImport(_Differentiation)
+import _Differentiation
+import Foundation
+internal import Numerics
+
+/// *n*-dimensional, locally-Euclidean topological space whose neighborhoods by which each of its
+/// points is contained are homeomorphic subsets of ℝ*ⁿ*, denoting a resemblance of such
+/// neighborhoods to an Euclidean space.
+public protocol Manifold {
+  /// Type of a point *p* in this ``Manifold``.
+  associatedtype Point: Differentiable
+}
+#endif

--- a/QuantumMechanics/Field/Space.swift
+++ b/QuantumMechanics/Field/Space.swift
@@ -1,0 +1,102 @@
+// ===-------------------------------------------------------------------------------------------===
+// Copyright © 2025 Supernova. All rights reserved.
+//
+// This file is part of the Deus open-source project.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program. If
+// not, see https://www.gnu.org/licenses.
+// ===-------------------------------------------------------------------------------------------===
+
+#if canImport(_Differentiation)
+import _Differentiation
+
+/// A "space" is a Deus-specific combination of a configuration space *Q* on a ``Manifold`` *M*; a
+/// Lagrangian phase space *TQ*, tangent to *Q*, containing pairs of coordinates *q* and velocities
+/// *q̇*; and a Hamiltonian phase space _T_*_Q_, a set of (*qⁱ*, *pᵢ*) cotagent to *Q*, associating
+/// each coordinate to its momentum.
+public protocol Space {
+  /// ``Manifold`` at which each configuration of this ``Space`` is.
+  associatedtype ConfigurationManifold: Manifold
+
+  /// ``Measurement`` resulted from calculating a ``lagrangianDensity(coordinate:velocity:time:)``.
+  /// Differs between the type of mechanics (i.e., quantum and classical) and interpretations within
+  /// quantum mechanics.
+  associatedtype LagrangianDensity: Measurement
+
+  /// Type of a coordinate in this ``Space``.
+  typealias Coordinate = ConfigurationManifold.Point
+
+  /// Sum of the mass of every configuration within this ``Space``.
+  var mass: Mass { get }
+
+  /// Calculates the Lagrangian density *𝐿* over the given coordinate and moment in time.
+  ///
+  /// The Lagrangian is a smooth, scalar function on the tangent bundle (the union of every tangent
+  /// space at all coordinates *qⁱ* in which lies the velocity *q̇ⁱ* associated to each of them;
+  /// i.e., a bundle whose coordinates are (*qⁱ*, *q̇ⁱ*)) of this ``Space``. It outputs the density
+  /// with which the `coordinate` moves over `time`, part of the formula for an action *S* (the path
+  /// of such coordinate):
+  ///
+  /// - *S*[*q*] = ∫*ᵗ²ₜ₁* *L*(*q*, *q̇*, *t*) × ∂*t*; or simply
+  /// - *S* = ∫*ᵗ²ₜ₁* *L* × ∂*t*.
+  ///
+  /// - Parameters:
+  ///   - coordinate: The coordinate *q*.
+  ///   - velocity: Rate of change *q̇* of the `coordinate` over `time`; its velocity in 1/c².
+  ///   - time: Time *t* at which the coordinate is.
+  /// - Returns: A unitized scalar in a Lagrangian density *𝐿*.
+  /// - SeeAlso: ``Speed/light``
+  func lagrangianDensity(
+    coordinate: Coordinate,
+    velocity: Coordinate.TangentVector,
+    time: Double
+  ) -> LagrangianDensity
+
+  /// Calculates the potential energy *V* = *E₀* - *Eₖ*, scalar function whose gradient outputs a
+  /// force, in this ``Space`` at a given coordinate and a specified time.
+  ///
+  /// - Parameters:
+  ///   - coordinate: The coordinate *q*.
+  ///   - time: Time *t* at which the coordinate is.
+  func potentialEnergy(coordinate: Coordinate, time: Double) -> Energy
+
+  /// The Lorentz factor *γ* quantifies the dilation of time, contraction of length and energy
+  /// relativization in a rest frame in relation to an event occurring at the given `velocity`.
+  ///
+  /// - Parameter velocity: Velocity of the event in 1/*c*.
+  /// - Returns: The dimensionless change in the system in which a ``Space`` is from a rest frame,
+  ///   resulted from the event.
+  /// - SeeAlso: ``Speed/light``
+  func lorentzFactor(velocity: Coordinate.TangentVector) -> Energy
+}
+
+extension Space {
+  /// The kinetic energy *Eₖ* describes the amount of energy of the motion of a coordinate *q*.
+  ///
+  /// - Parameter velocity: Velocity of *q* in 1/c.
+  /// - SeeAlso: ``Speed/light``
+  public func kineticEnergy(velocity: Coordinate.TangentVector) -> Energy {
+    .joules((lorentzFactor(velocity: velocity).quantityInBaseUnit - 1) * mass.quantityInBaseUnit)
+  }
+}
+
+extension Space
+where Coordinate.TangentVector: FloatingPoint, Coordinate.TangentVector.Magnitude == Double {
+  public func lorentzFactor(velocity: ConfigurationManifold.Point.TangentVector) -> Energy {
+    let lightSpeedInMetersPerSecond = Speed.light(1).quantityInBaseUnit
+    return .joules(
+      1
+        / (1 - velocity * velocity / lightSpeedInMetersPerSecond * lightSpeedInMetersPerSecond)
+        .squareRoot()
+    )
+  }
+}
+#endif

--- a/QuantumMechanics/Measurement+Differentiable.swift
+++ b/QuantumMechanics/Measurement+Differentiable.swift
@@ -1,0 +1,44 @@
+// ===-------------------------------------------------------------------------------------------===
+// Copyright © 2026 Supernova. All rights reserved.
+//
+// This file is part of the Deus open-source project.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program. If
+// not, see https://www.gnu.org/licenses.
+// ===-------------------------------------------------------------------------------------------===
+
+#if canImport(_Differentiation)
+import _Differentiation
+
+extension Angle: Differentiable {
+  public typealias TangentVector = Self
+
+  public mutating func move(by offset: Self) { self += offset }
+}
+
+extension ElectricCharge: Differentiable {
+  public typealias TangentVector = Self
+
+  public mutating func move(by offset: Self) { self += offset }
+}
+
+extension Mass: Differentiable {
+  public typealias TangentVector = Self
+
+  public mutating func move(by offset: Self) { self += offset }
+}
+
+extension Speed: Differentiable {
+  public typealias TangentVector = Self
+
+  public mutating func move(by offset: Self) { self += offset }
+}
+#endif

--- a/QuantumMechanics/Measurement+Differentiable.swift.gyb
+++ b/QuantumMechanics/Measurement+Differentiable.swift.gyb
@@ -1,0 +1,43 @@
+%{
+  # ===------------------------------------------------------------------------------------------===
+  # Copyright © 2025 Supernova. All rights reserved.
+  #
+  # This file is part of the Deus open-source project.
+  #
+  # This program is free software: you can redistribute it and/or modify it under the terms of the
+  # GNU General Public License as published by the Free Software Foundation, either version 3 of the
+  # License, or (at your option) any later version.
+  #
+  # This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  # without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+  # the GNU General Public License for more details.
+  #
+  # You should have received a copy of the GNU General Public License along with this program. If
+  # not, see https://www.gnu.org/licenses.
+  # ===------------------------------------------------------------------------------------------===
+
+  from os import environ
+  from reflection import licensing
+  from reflection import quantum_mechanics
+
+  all_measurement_types = quantum_mechanics.all_measurement_types()
+}%
+${licensing.header()}
+
+#if canImport(_Differentiation)
+import _Differentiation
+
+% for index, measurement in enumerate(all_measurement_types):
+  % Self = measurement.identifier
+extension ${Self}: Differentiable {
+  public typealias TangentVector = Self
+
+  public mutating func move(by offset: Self) {
+    self += offset
+  }
+}
+  % if index < len(all_measurement_types) - 1:
+
+  % end
+% end
+#endif

--- a/QuantumMechanicsTests/Field/ManifoldTests.swift
+++ b/QuantumMechanicsTests/Field/ManifoldTests.swift
@@ -1,0 +1,61 @@
+// ===-------------------------------------------------------------------------------------------===
+// Copyright © 2025 Supernova. All rights reserved.
+//
+// This file is part of the Deus open-source project.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the
+// GNU General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with this program. If
+// not, see https://www.gnu.org/licenses.
+// ===-------------------------------------------------------------------------------------------===
+
+#if canImport(_Differentiation)
+import Testing
+
+@testable import QuantumMechanics
+
+struct ManifoldTests {
+  @Test
+  func calculatesLagrangian() { #expect(RealLine(mass: .zero).kineticEnergy(velocity: 0) == .zero) }
+}
+
+/// 1-dimensional, unitary ``Space``.
+private struct RealLine: Space {
+  public typealias ConfigurationManifold = UnidimensionalManifold
+
+  public let mass: Mass
+
+  public func lagrangianDensity(
+    coordinate: UnidimensionalManifold.Point,
+    velocity: UnidimensionalManifold.Point.TangentVector,
+    time: Double
+  ) -> Energy {
+    kineticEnergy(velocity: velocity) - potentialEnergy(coordinate: coordinate, time: time)
+  }
+
+  /// Potential ``Energy`` *V* = *E₀* - *Eₖ*, scalar function whose gradient outputs a force, at the
+  /// given coordinate and time. Since this 1D ``Space`` exists only for testing purposes and
+  /// strives to be as simple as possible in terms of calculus, its *V* at any coordinate and time
+  /// will always be zero.
+  ///
+  /// - Parameters:
+  ///   - coordinate: The coordinate *q*.
+  ///   - time: Time *t* at which the coordinate is.
+  /// - Returns: Zero; this implementation of a real line contains no potential ``Energy``.
+  /// - SeeAlso: ``Space/kineticEnergy(velocity:)``
+  public func potentialEnergy(coordinate: UnidimensionalManifold.Point, time: Double) -> Energy {
+    .zero
+  }
+}
+
+/// 1-dimensional, unitary ``Manifold``.
+private struct UnidimensionalManifold {}
+
+extension UnidimensionalManifold: Manifold { public typealias Point = Double }
+#endif

--- a/QuantumMechanicsTests/MeasurementTests.swift.gyb
+++ b/QuantumMechanicsTests/MeasurementTests.swift.gyb
@@ -117,6 +117,16 @@ fileprivate struct ${Self}Tests {
     #expect(converted.quantityInBaseUnit == initial.quantityInBaseUnit)
     #expect(converted.symbol == ${Self}.in(unitRepresentable.unit).symbol)
   }
+
+  #if canImport(_Differentiation)
+  @Test(arguments: ${measurements_expression})
+  func moves(_ initial: ${Self}) {
+    var moved = initial
+    moved.move(by: 2)
+    #expect(moved.quantityInBaseUnit == initial.quantityInBaseUnit + 2)
+    #expect(moved.symbol == initial.symbol)
+  }
+  #endif
 }
 
 % end


### PR DESCRIPTION
Adds the notion of fields to the [`QuantumMechanics`](https://github.com/project-deus/Deus/tree/629a00a9d81a19820639552d3ade60822f79dfab/QuantumMechanics) framework. (Quantum mechanics and field theories are quite intertwined as per the current structure of the project. There shall be an effort put onto differentiating one from the other in the future; some kind of enum for selecting which theory to apply on the simulation, maybe?)

This is crucial for emergence, which is the envisioned foundation of Deus.

---

An atlas $\mathcal{A} = \set{(U _\alpha, \varphi _\alpha) \mid \alpha \in I}$ is a set of pairs of charts $U _\alpha$ and their homeomorphism $\varphi _\alpha \colon U _\alpha \rightarrow V _\alpha$, where $U _\alpha \subseteq M$ and $V _\alpha \subseteq \mathbb{R}^n$. An $n$-dimensional manifold $M$ is, then, a topological space whose distinct points have disjoint neighborhoods (that is: is a Hausdorff space); given a basis $B = \set{A_i} _{i \in \mathbb{N}}$, where $U _\alpha = \bigcup\set{ A_i \in B \mid A_i \subseteq U _\alpha}$, such space is also second-countable — $B$ contains open subsets of $M$.